### PR TITLE
Bugfix

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1,7 +1,10 @@
 <?PHP
 
+defined("MOODLE_INTERNAL") || die();
+
 //require_once($CFG->libdir.'/filelib.php');
 //require_once("$CFG->dirroot/files/mimetypes.php");
+require_once($CFG->dirroot . '/calendar/lib.php');
 
 //define("OFFLINE",      "0");
 //define("UPLOADSINGLE", "1");


### PR DESCRIPTION
calendar_event class is not loaded automatically by moodle (unless you are in a course).
Changing the registration settings will result in a fatal error, because this class is not defined.

Therefore a quick fix for this issue:
`calendar/lib.php` is now required and `MOODLE_INTERNAL` has to be defined (or `die`).
If not, there would be a fatal error in the call of `require_once` anyway.

```
modified:   lib.php
```
